### PR TITLE
(feat) all user canvases are displayed and are redrawn on data change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "jquery": "~2.1.3",
-    "firebase": "~2.2.2"
+    "firebase": "~2.2.2",
+    "cryptojs": "*"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~2.1.3"
+    "jquery": "~2.1.3",
+    "firebase": "~2.2.2"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,7 @@
       "matches": ["<all_urls>"],
       "js": [
         "src/bower_components/jquery/dist/jquery.js",
+        "src/bower_components/firebase/firebase.js",
         "src/content-scripts/canvas.js"
       ]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,7 @@
       "js": [
         "src/bower_components/jquery/dist/jquery.js",
         "src/bower_components/firebase/firebase.js",
+        "src/libs/sha1.js",
         "src/content-scripts/canvas.js"
       ]
     }

--- a/src/app/main/main.js
+++ b/src/app/main/main.js
@@ -61,6 +61,7 @@ angular.module('graffio.mainController', [])
     
   // function called when button is pressed by user wishing to toggle the current state
   $scope.toggleStatus = function() {
+
     // figure out what existing state is from the content script
     getStatus(function(status, tabID) {
       // send a message to the tab and also set the current button value to be the opposite

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -16,6 +16,7 @@ chrome.runtime.onMessage.addListener(function(request,sender,sendResponse) {
       sendResponse({token: userToken});  
     } else {
       console.log('userToken not yet set');
+      sendResponse({token: null}); 
     }
   }
 

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -25,7 +25,9 @@ var url = "testUrl3";
 var ref = new Firebase('https://dazzling-heat-2465.firebaseio.com/web/data/sites/' + url);
 
 ref.on("value", function(snapshot) {
-  testdata = snapshot.val();
+  testdata = snapshot.val()['testUser3'];
+  appendPublicCanvas();
+  console.log(testdata)
 }, function (errorObject) {
   console.log("The read failed: " + errorObject.code);
 });
@@ -56,8 +58,12 @@ function toggleCanvasOn(){
       .attr('width', document.body.scrollWidth) // sets to max width
       .attr('height', document.body.scrollHeight) // sets to max height
       .on('mousemove', function(e){findxy('move', e)})
-      .on('mousedown', function(e){findxy('down', e)})
-      .on('mouseup', function(e){findxy('up', e)})
+      .on('mousedown', function(e){findxy('down', e);})
+      .on('mouseup', function(e){
+        console.log('up')
+        findxy('up', e); 
+        saveUserCanvas();
+      })
       .on('mouseout', function(e){ findxy('out', e)})
       .appendTo('body');
 
@@ -74,6 +80,7 @@ function toggleCanvasOff(){
 
 function saveUserCanvas(){
   var data = canvas.toDataURL();
+  console.log(data)
   ref.child(user).set(data)
 };
 
@@ -82,21 +89,28 @@ function loadPublicCanvas(){
 };
 
 function appendPublicCanvas() {
-  var img = new Image();
-  img.src = testdata;
+  console.log('append')
 
-  $('<canvas id="graffio-canvas"></canvas>').innerHTML = ''
-  var newCanvas = $('<canvas id="graffio-canvas"></canvas>')
-      .css(overlayPage)
-      .attr('width', document.body.scrollWidth) // sets to max width
-      .attr('height', document.body.scrollHeight) // sets to max height
-      .appendTo('body');
-  var newCtx = newCanvas.getContext('2d');
+  $('<canvas id="public"></canvas>')
+    .css({
+      position: 'absolute',
+      top: 0,
+      left: 0
+    })
+    .attr('width', document.body.scrollWidth) // sets to max width
+    .attr('height', document.body.scrollHeight) // sets to max height
+    .appendTo('body');
 
-  img.onload = function () {
-    newCtx.drawImage(img,0,0);
-  }
-}
+  var publicCanvas = document.getElementById('public')
+  var context = publicCanvas.getContext('2d');
+  var imageObj = new Image();
+
+  imageObj.src = testdata;
+  
+  imageObj.onload = function() {
+    context.drawImage(this, 0, 0);
+  };
+};
 
 function draw() {
   ctx.beginPath();
@@ -130,7 +144,6 @@ function findxy(res, e) {
       currX = e.clientX - canvas.offsetLeft;
       currY = e.clientY - canvas.offsetTop;
       draw();
-      saveUserCanvas()
     }
   }
 }

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -47,7 +47,7 @@ function getFirebaseAuthData(){
   });
 };
 
-function toggleCanvasOn(){
+function toggleUserCanvasOn(){
   if (toggle === 'off') {
     $('<canvas id="graffio-canvas"></canvas>')
       .css({zIndex: 100, position: 'absolute', top: 0,left: 0})
@@ -68,7 +68,7 @@ function toggleCanvasOn(){
   }
 };
 
-function toggleCanvasOff(){
+function toggleUserCanvasOff(){
   $('canvas#graffio-canvas').remove();
   console.log('user canvas removed!');
 };
@@ -79,6 +79,19 @@ function saveUserCanvas(){
   ref.child(userId).set(data)
 };
 
+function loadPublicCanvas(){
+  
+
+};
+
+function appendPublicCanvas(){
+
+};
+
+function redrawCanvas(){
+
+};
+
 function draw() {
   ctx.beginPath();
   ctx.moveTo(prevX+pageXOffset, prevY+pageYOffset);
@@ -87,7 +100,7 @@ function draw() {
   ctx.lineWidth = lineWidth;
   ctx.stroke();
   ctx.closePath();
-}
+};
 
 function findxy(res, e) { 
   if (res == 'down') {
@@ -113,4 +126,4 @@ function findxy(res, e) {
       draw();
     }
   }
-}
+};

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -10,9 +10,6 @@ var lineColor = 'black',
     lineWidth = 2;
 
 var toggle = 'off';
-var accessToken;
-var authData;
-
 
 var tabUrl = CryptoJS.SHA1(document.URL);
 var ref = new Firebase('https://dazzling-heat-2465.firebaseio.com/web/data/sites/' + tabUrl);
@@ -23,7 +20,6 @@ chrome.runtime.onMessage.addListener(
     console.log('message:', request, ' from sender: ', sender);
     if (request.toggle === 'off') {
         toggleCanvasOff();
-        appendPublicCanvas();
         toggle = 'off';
         appendPublicCanvas();
         sendResponse({confirm:'canvas turned off'});
@@ -58,7 +54,6 @@ function getFirebaseAuthData(){
   });
 };
 
-
 function toggleUserCanvasOn(){
   if (toggle === 'off') {
     $('<canvas id="graffio-canvas"></canvas>')
@@ -68,7 +63,6 @@ function toggleUserCanvasOn(){
       .on('mousemove', function(e){findxy('move', e)})
       .on('mousedown', function(e){findxy('down', e);})
       .on('mouseup', function(e){
-        console.log('up')
         findxy('up', e); 
         saveUserCanvas();
       })

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -34,6 +34,13 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
+ref.on("value", function(snapshot) {
+  allCanvases = snapshot.val();
+  console.log(allCanvases);
+}, function (errorObject) {
+  console.log("The read failed: " + errorObject.code);
+});
+
 function getFirebaseAuthData(){
   chrome.runtime.sendMessage({action: 'getToken'}, function(response) {
     if (response.token) {

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -36,10 +36,6 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
-ref.on("value", function(snapshot){
-  appendCanvasAll(snapshot);
-})
-
 function getFirebaseAuthData(){
   chrome.runtime.sendMessage({action: 'getToken'}, function(response) {
     if (response.token) {
@@ -87,45 +83,6 @@ function saveUserCanvas(){
 
 function removeCanvasAll(){
  $('canvas').remove();
-};
-
-function appendCanvasAll(snapshot){
-  console.log('hello')
-
-  var allCanvases = snapshot.val();
-  console.log(allCanvases)
-  // for (var user in allCanvases){
-
-    // var data = allCanvases[userId];
-  
-    // $('<canvas id="public"></canvas>')
-    //   .css({position: 'absolute', top: 0, left: 0})
-    //   .attr('width', document.body.scrollWidth)
-    //   .attr('height', document.body.scrollHeight)
-    //   .attr('class', user)
-    //   .appendTo('body');
-
-    // var publicCanvas = document.getElementsByClassName(user);
-    // var context = publicCanvas.getContext('2d');
-    // var imageObj = new Image();
-
-    // imageObj.src = data;
-    
-    // imageObj.onload = function() {
-    //   context.drawImage(this, 0, 0);
-    // };  
-  // }
-};
-
-function redrawCanvas(canvasElement, data){
-  var context = canvasElement.getContext('2d');
-  var imageObj = new Image();
-
-  imageObj.src = data;
-  
-  imageObj.onload = function() {
-    context.drawImage(this, 0, 0);
-  };
 };
 
 function draw() {

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -10,56 +10,18 @@ var lineColor = 'black',
     lineWidth = 2;
 
 var toggle = 'off',
-    showCanvasAll = true;
+    showCanvasAll = true,
+    currentUser;
 
 var tabUrl = CryptoJS.SHA1(document.URL),
     ref = new Firebase('https://dazzling-heat-2465.firebaseio.com/web/data/sites/' + tabUrl);
-    currentUser;
 
-// Message Handler
-chrome.runtime.onMessage.addListener(
-  function (request, sender, sendResponse) {
-    console.log('message:', request, ' from sender: ', sender);
-
-    // Toggle User Canvas Messages
-    if (request.toggle === 'off') {
-        toggleUserCanvasOff();
-        sendResponse({confirm:'canvas turned off'});
-    } else if (request.toggle === 'on') {
-        toggleUserCanvasOn();
-        getFirebaseAuthData();
-        sendResponse({confirm:'canvas turned on'});
-    } else if (request.getStatus === true) {
-      sendResponse({status:toggle});
-
-    // Logout Messages
-    } else if (request.logout) {
-      removeCanvasAll();
-
-    // Show Public Canvases Messages
-    } else if (request.show === 'all') {
-      showCanvasAll === true;
-    } else if (request.show === 'none') {
-       showCanvasAll === false;
-       removePublicCanvasAll();
-    }
-  }
-);
-
-// Firebase Event Listener 
-ref.on("value", function(snapshot){
-  if (showCanvasAll) {
-    console.log('value')
-    updateCanvasElements(snapshot);
-  } 
-})
-
-function getFirebaseAuthData(){
+var getFirebaseAuthData = function(){
   chrome.runtime.sendMessage({action: 'getToken'}, function(response) {
     if (response.token) {
       ref.authWithCustomToken(response.token, function(error, result) {
-        if (error) {console.log("Login Failed!", error);} 
-        else {currentUser=result.uid;}
+        if (error) { console.log("Login Failed!", error); } 
+        else { currentUser = result.uid; }
       });
     } else {
       console.log('no token found');
@@ -67,64 +29,19 @@ function getFirebaseAuthData(){
   });
 };
 
-function toggleUserCanvasOn(){
-  if (toggle === 'off') {
-    appendCanvasElement(currentUser);
-    toggle = 'on';
-  }
-};
-
-function toggleUserCanvasOff(){
-  $('canvas#graffio-canvas').remove();
-  toggle = 'off';
-  console.log('user canvas removed!');
-};
-
-function saveUserCanvas(){
-  console.log('saving user canvas')
-  var data = canvas.toDataURL();
-  ref.child(currentUser).set(data)
-};
-
-function removeCanvasAll(){
- $('canvas').remove();
-};
-
-function removePublicCanvasAll(){
- $('canvas#public').remove();
-};
-
-function updateCanvasElements(snapshot){
-  var allCanvases = snapshot.val();
-  var data, publicCanvas;
-
-  for (var user in allCanvases){
-    if ( user !== currentUser ){
-      data = allCanvases[user];
-
-      if ( document.getElementsByClassName(user).length >=1 ) {
-        publicCanvas = document.getElementsByClassName(user)[0];
-        drawCanvasElement(publicCanvas, data);
-      } else {
-        appendCanvasElement(user);
-        publicCanvas = document.getElementsByClassName(user)[0];
-        drawCanvasElement(publicCanvas, data);
-      }
-    }
-  }
-};
-
-function drawCanvasElement(canvasElement, data){
+var drawCanvasElement = function(canvasElement, data){
   var context = canvasElement.getContext('2d');
   var imageObj = new Image();
   imageObj.src = data;
-  imageObj.onload = function() {
+  imageObj.onload = function(){
     context.drawImage(this, 0, 0);
   };
 };
 
-function appendCanvasElement(user){
-  if( user === currentUser ) {
+var appendCanvasElement = function(user){
+
+  // Append User Canvas
+  if( user === currentUser ){
     $('<canvas id="graffio-canvas"></canvas>')
       .css({zIndex: 100, position: 'absolute', top: 0,left: 0})
       .attr('width', document.body.scrollWidth)
@@ -142,9 +59,11 @@ function appendCanvasElement(user){
     ctx = canvas.getContext("2d");
 
     console.log('user canvas injected!');
+
+  // Append Public Canvas
   } else {
     $('<canvas id="public"></canvas>')
-      .css({position: 'absolute', top: 0, left: 0})
+      .css({position: 'absolute', top: 0, left: 0, 'pointer-events': 'none'})
       .attr('width', document.body.scrollWidth)
       .attr('height', document.body.scrollHeight)
       .attr('class', user)
@@ -152,9 +71,62 @@ function appendCanvasElement(user){
 
     console.log('public canvas injected!');
   }
-}
+};
 
-function drawLine() {
+var updateCanvasElements = function(snapshot){
+  var allCanvases = snapshot.val();
+  var data, publicCanvas;
+
+  for (var user in allCanvases){
+    if ( user !== currentUser ){
+      data = allCanvases[user];
+
+      // If user's public canvas element already exists, then update
+      if ( document.getElementsByClassName(user).length >=1 ) {
+        publicCanvas = document.getElementsByClassName(user)[0];
+        drawCanvasElement(publicCanvas, data);
+
+      // Else, doesn't exist already, then append and reconstruct it
+      } else {
+        appendCanvasElement(user);
+        publicCanvas = document.getElementsByClassName(user)[0];
+        drawCanvasElement(publicCanvas, data);
+      }
+    }
+  }
+};
+
+var toggleUserCanvasOn = function(){
+  if ( toggle === 'off' ) {
+    appendCanvasElement(currentUser);
+    toggle = 'on';
+  }
+};
+
+var toggleUserCanvasOff = function(){
+  $('canvas#graffio-canvas').remove();
+  toggle = 'off';
+  console.log('user canvas removed!');
+};
+
+var saveUserCanvas = function(){
+  var data = canvas.toDataURL();
+  ref.child(currentUser).set(data);
+  console.log('saving user canvas');
+};
+
+
+var removePublicCanvasAll = function(){
+ $('canvas#public').remove();
+};
+
+var removeCanvasAll = function(){
+  toggleUserCanvasOff();
+  removePublicCanvasAll();
+};
+
+
+var drawLine = function(){
   ctx.beginPath();
   ctx.moveTo(prevX+pageXOffset, prevY+pageYOffset);
   ctx.lineTo(currX+pageXOffset, currY+pageYOffset);
@@ -164,7 +136,7 @@ function drawLine() {
   ctx.closePath();
 };
 
-function findxy(res, e) { 
+var findxy = function(res, e){ 
   if (res == 'down') {
     flag = true;
     prevX = currX;
@@ -189,3 +161,45 @@ function findxy(res, e) {
     }
   }
 };
+
+// Message Handler
+chrome.runtime.onMessage.addListener(
+  function (request, sender, sendResponse){
+    console.log('message:', request, ' from sender: ', sender);
+
+    // Toggle User Canvas Messages
+    if ( request.toggle === 'off' ){
+        toggleUserCanvasOff();
+        sendResponse({confirm:'canvas turned off'});
+    } else if ( request.toggle === 'on' ){
+        toggleUserCanvasOn();
+        getFirebaseAuthData();
+        sendResponse({confirm:'canvas turned on'});
+
+    // Initialize toggle status for popup button
+    } else if ( request.getStatus === true ){
+      console.log('status')
+      sendResponse({status:toggle});
+
+    // Logout Messages
+    } else if (request.logout){
+      removeCanvasAll();
+
+    // Show Public Canvases Messages
+    } else if ( request.show === 'all' ){
+      showCanvasAll === true;
+    } else if ( request.show === 'none' ){
+       showCanvasAll === false;
+       removePublicCanvasAll();
+    }
+  }
+);
+
+// Firebase Event Listener 
+ref.on("value", function(snapshot){
+  if (showCanvasAll) {
+    updateCanvasElements(snapshot);
+  } 
+})
+
+

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -86,6 +86,19 @@ function saveUserCanvas(){
   ref.child(userId).set(data)
 };
 
+function loadPublicCanvas(){
+  
+
+};
+
+function appendPublicCanvas(){
+
+};
+
+function redrawCanvas(){
+
+};
+
 function draw() {
   ctx.beginPath();
   ctx.moveTo(prevX+pageXOffset, prevY+pageYOffset);

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -36,6 +36,11 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
+ref.on("value", function(snapshot){
+  console.log("CHANGE EVENT")
+  appendCanvasAll(snapshot);
+})
+
 function getFirebaseAuthData(){
   chrome.runtime.sendMessage({action: 'getToken'}, function(response) {
     if (response.token) {
@@ -84,6 +89,73 @@ function saveUserCanvas(){
 function removeCanvasAll(){
  $('canvas').remove();
 };
+
+function appendCanvasAll(snapshot){
+  console.log('hello')
+
+  var allCanvases = snapshot.val();
+  for (var user in allCanvases){
+
+    console.log(user)
+    console.log(document.getElementsByClassName(user).length)
+
+    // console.log('user is a ', typeof user, ' and ', user);
+    // console.log('allCanvases is a ', typeof allCanvases, ' and ', allCanvases);
+    // console.log('this is a ', typeof allCanvases[user], ' and ', allCanvases[user]);
+
+    
+    
+    if (document.getElementsByClassName(user).length > 1) {
+      console.log('canvas element already exists')
+
+      var publicCanvas = document.getElementsByClassName(user)[0];
+      var data = allCanvases[user];
+
+      drawCanvas(publicCanvas, data);
+
+    } else {
+      console.log(user)
+      $('<canvas id="public"></canvas>')
+        .css({position: 'absolute', top: 0, left: 0})
+        .attr('width', document.body.scrollWidth)
+        .attr('height', document.body.scrollHeight)
+        .attr('class', user)
+        .appendTo('body');
+
+      var data = allCanvases[user];
+      console.log(data)
+      var publicCanvas = document.getElementsByClassName(user)[0];
+      console.log(publicCanvas)
+      var context = publicCanvas.getContext('2d');
+      var imageObj = new Image();
+
+      imageObj.src = data;
+      
+      imageObj.onload = function() {
+        context.drawImage(this, 0, 0);
+      };   
+    }
+
+  }
+};
+
+function drawCanvas(canvasElement, data){
+  var context = canvasElement.getContext('2d');
+  var imageObj = new Image();
+  imageObj.src = data;
+  imageObj.onload = function() {
+    context.drawImage(this, 0, 0);
+  };
+};
+
+function appendCanvasElement(user){
+  $('<canvas id="public"></canvas>')
+    .css({position: 'absolute', top: 0, left: 0})
+    .attr('width', document.body.scrollWidth)
+    .attr('height', document.body.scrollHeight)
+    .attr('class', user)
+    .appendTo('body');
+}
 
 function draw() {
   ctx.beginPath();

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -65,6 +65,7 @@ function toggleUserCanvasOn(){
       .on('mousemove', function(e){findxy('move', e)})
       .on('mousedown', function(e){findxy('down', e);})
       .on('mouseup', function(e){
+        console.log('up')
         findxy('up', e); 
         saveUserCanvas();
       })
@@ -86,12 +87,6 @@ function saveUserCanvas(){
   console.log('saving user canvas')
   var data = canvas.toDataURL();
   ref.child(userId).set(data)
-};
-
-
-function appendPublicCanvas(){
-  var data = canvas.toDataURL();
-  ref.child(user).set(data)
 };
 
 function draw() {
@@ -126,7 +121,6 @@ function findxy(res, e) {
       currX = e.clientX - canvas.offsetLeft;
       currY = e.clientY - canvas.offsetTop;
       draw();
-      saveUserCanvas()
     }
   }
 };

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -20,11 +20,13 @@ chrome.runtime.onMessage.addListener(
     console.log('message:', request, ' from sender: ', sender);
     if (request.toggle === 'off') {
         toggleCanvasOff();
+        appendPublicCanvas();
         toggle = 'off';
         appendPublicCanvas();
         sendResponse({confirm:'canvas turned off'});
     } else if (request.toggle === 'on') {
         toggleCanvasOn();
+
         toggle = 'on';
         getFirebaseAuthData();
         sendResponse({confirm:'canvas turned on'});
@@ -86,17 +88,10 @@ function saveUserCanvas(){
   ref.child(userId).set(data)
 };
 
-function loadPublicCanvas(){
-  
-
-};
 
 function appendPublicCanvas(){
-
-};
-
-function redrawCanvas(){
-
+  var data = canvas.toDataURL();
+  ref.child(user).set(data)
 };
 
 function draw() {
@@ -131,6 +126,7 @@ function findxy(res, e) {
       currX = e.clientX - canvas.offsetLeft;
       currY = e.clientY - canvas.offsetTop;
       draw();
+      saveUserCanvas()
     }
   }
 };

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -36,16 +36,9 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
-ref.on("value", function(snapshot) {
-  var allCanvases = snapshot.val();
-
-  for (var user in allCanvases){
-    var canvasData = allCanvases[user];
-    appendCanvas(canvasData);
-  }
-}, function (errorObject) {
-  console.log("The read failed: " + errorObject.code);
-});
+ref.on("value", function(snapshot){
+  appendCanvasAll(snapshot);
+})
 
 function getFirebaseAuthData(){
   chrome.runtime.sendMessage({action: 'getToken'}, function(response) {
@@ -96,14 +89,44 @@ function removeCanvasAll(){
  $('canvas').remove();
 };
 
+function appendCanvasAll(snapshot){
+  console.log('hello')
 
-function appenCavnas(data){
+  var allCanvases = snapshot.val();
+  console.log(allCanvases)
+  // for (var user in allCanvases){
 
+    // var data = allCanvases[userId];
+  
+    // $('<canvas id="public"></canvas>')
+    //   .css({position: 'absolute', top: 0, left: 0})
+    //   .attr('width', document.body.scrollWidth)
+    //   .attr('height', document.body.scrollHeight)
+    //   .attr('class', user)
+    //   .appendTo('body');
+
+    // var publicCanvas = document.getElementsByClassName(user);
+    // var context = publicCanvas.getContext('2d');
+    // var imageObj = new Image();
+
+    // imageObj.src = data;
+    
+    // imageObj.onload = function() {
+    //   context.drawImage(this, 0, 0);
+    // };  
+  // }
 };
 
-// function redrawCanvas(){
+function redrawCanvas(canvasElement, data){
+  var context = canvasElement.getContext('2d');
+  var imageObj = new Image();
 
-// };
+  imageObj.src = data;
+  
+  imageObj.onload = function() {
+    context.drawImage(this, 0, 0);
+  };
+};
 
 function draw() {
   ctx.beginPath();

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -10,6 +10,9 @@ var lineColor = 'black',
     lineWidth = 2;
 
 var toggle = 'off';
+var accessToken;
+var authData;
+
 
 var tabUrl = CryptoJS.SHA1(document.URL);
 var ref = new Firebase('https://dazzling-heat-2465.firebaseio.com/web/data/sites/' + tabUrl);
@@ -26,7 +29,6 @@ chrome.runtime.onMessage.addListener(
         sendResponse({confirm:'canvas turned off'});
     } else if (request.toggle === 'on') {
         toggleCanvasOn();
-
         toggle = 'on';
         getFirebaseAuthData();
         sendResponse({confirm:'canvas turned on'});
@@ -55,6 +57,7 @@ function getFirebaseAuthData(){
     }
   });
 };
+
 
 function toggleUserCanvasOn(){
   if (toggle === 'off') {

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -19,24 +19,30 @@ chrome.runtime.onMessage.addListener(
   function (request, sender, sendResponse) {
     console.log('message:', request, ' from sender: ', sender);
     if (request.toggle === 'off') {
-        toggleCanvasOff();
+        toggleUserCanvasOff();
         toggle = 'off';
         appendPublicCanvas();
         sendResponse({confirm:'canvas turned off'});
     } else if (request.toggle === 'on') {
-        toggleCanvasOn();
+        toggleUserCanvasOn();
         toggle = 'on';
         getFirebaseAuthData();
         sendResponse({confirm:'canvas turned on'});
     } else if (request.getStatus === true) {
       sendResponse({status:toggle});
+    } else if (request.logout) {
+      removeCanvasAll();
     }
   }
 );
 
 ref.on("value", function(snapshot) {
-  allCanvases = snapshot.val();
-  console.log(allCanvases);
+  var allCanvases = snapshot.val();
+
+  for (var user in allCanvases){
+    var canvasData = allCanvases[user];
+    appendCanvas(canvasData);
+  }
 }, function (errorObject) {
   console.log("The read failed: " + errorObject.code);
 });
@@ -86,18 +92,18 @@ function saveUserCanvas(){
   ref.child(userId).set(data)
 };
 
-function loadPublicCanvas(){
-  
+function removeCanvasAll(){
+ $('canvas').remove();
+};
+
+
+function appenCavnas(data){
 
 };
 
-function appendPublicCanvas(){
+// function redrawCanvas(){
 
-};
-
-function redrawCanvas(){
-
-};
+// };
 
 function draw() {
   ctx.beginPath();

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -9,12 +9,12 @@ var canvas, ctx, flag = false,
 var lineColor = 'black',
     lineWidth = 2;
 
-var toggle = 'off';
-var showCanvasAll = true;
+var toggle = 'off',
+    showCanvasAll = true;
 
-var tabUrl = CryptoJS.SHA1(document.URL);
-var ref = new Firebase('https://dazzling-heat-2465.firebaseio.com/web/data/sites/' + tabUrl);
-var currentUser;
+var tabUrl = CryptoJS.SHA1(document.URL),
+    ref = new Firebase('https://dazzling-heat-2465.firebaseio.com/web/data/sites/' + tabUrl);
+    currentUser;
 
 // Message Handler
 chrome.runtime.onMessage.addListener(
@@ -96,11 +96,9 @@ function removePublicCanvasAll(){
 
 function updateCanvasElements(snapshot){
   var allCanvases = snapshot.val();
-  var data;
-  var publicCanvas;
+  var data, publicCanvas;
 
   for (var user in allCanvases){
-    console.log(user, currentUser)
     if ( user !== currentUser ){
       data = allCanvases[user];
 
@@ -117,7 +115,6 @@ function updateCanvasElements(snapshot){
 };
 
 function drawCanvasElement(canvasElement, data){
-  console.log(canvasElement)
   var context = canvasElement.getContext('2d');
   var imageObj = new Image();
   imageObj.src = data;
@@ -127,7 +124,6 @@ function drawCanvasElement(canvasElement, data){
 };
 
 function appendCanvasElement(user){
-  console.log(user, currentUser)
   if( user === currentUser ) {
     $('<canvas id="graffio-canvas"></canvas>')
       .css({zIndex: 100, position: 'absolute', top: 0,left: 0})

--- a/src/content-scripts/canvas.js
+++ b/src/content-scripts/canvas.js
@@ -49,6 +49,7 @@ chrome.runtime.onMessage.addListener(
 // Firebase Event Listener 
 ref.on("value", function(snapshot){
   if (showCanvasAll) {
+    console.log('value')
     updateCanvasElements(snapshot);
   } 
 })
@@ -95,17 +96,22 @@ function removePublicCanvasAll(){
 
 function updateCanvasElements(snapshot){
   var allCanvases = snapshot.val();
-  var data = allCanvases[user];
+  var data;
   var publicCanvas;
 
   for (var user in allCanvases){
-    if ( document.getElementsByClassName(user) >=1 ) {
-      publicCanvas = document.getElementsByClassName(user)[0];
-      drawCanvasElement(publicCanvas, data);
-    } else {
-      appendCanvasElement(user);
-      publicCanvas = document.getElementsByClassName(user)[0];
-      drawCanvasElement(publicCanvas, data);
+    console.log(user, currentUser)
+    if ( user !== currentUser ){
+      data = allCanvases[user];
+
+      if ( document.getElementsByClassName(user).length >=1 ) {
+        publicCanvas = document.getElementsByClassName(user)[0];
+        drawCanvasElement(publicCanvas, data);
+      } else {
+        appendCanvasElement(user);
+        publicCanvas = document.getElementsByClassName(user)[0];
+        drawCanvasElement(publicCanvas, data);
+      }
     }
   }
 };
@@ -121,6 +127,7 @@ function drawCanvasElement(canvasElement, data){
 };
 
 function appendCanvasElement(user){
+  console.log(user, currentUser)
   if( user === currentUser ) {
     $('<canvas id="graffio-canvas"></canvas>')
       .css({zIndex: 100, position: 'absolute', top: 0,left: 0})


### PR DESCRIPTION
With this implementation, users can draw on their canvas and see what others are drawing on the site in realtime. 

For testing purposes, all user canvases are displayed on a site. Eventually, there should be a toggle on/off button for showing and hiding what others are drawing on the site.

I'm not quite sure if the canvas.js file should contain this much code. It does seem a bit strange to hold so much of the apps logic in this file. 
